### PR TITLE
Fork fix to help with issue found at work CHEC-7016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /vendor/*
 .phpunit.result.cache
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8",
         "doctrine/common": "^2.13.3 || ^3.2.2",
+        "phpspec/prophecy": "^1.20",
         "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
     },
     "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         colors="true">
-
-    <testsuites>
-        <testsuite name="Test suite">
-            <directory>./tests/DeepCopyTest</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-            <exclude>
-                <file>src/DeepCopy/deep_copy.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <exclude>
+      <file>src/DeepCopy/deep_copy.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test suite">
+      <directory>./tests/DeepCopyTest</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -175,10 +175,15 @@ class DeepCopy
      */
     private function copyObject($object)
     {
+        $objectClass = get_class($object);
         $objectHash = spl_object_hash($object);
 
-        if (isset($this->hashMap[$objectHash])) {
-            return $this->hashMap[$objectHash];
+        if (!isset($this->hashMap[$objectHash])) {
+            $this->hashMap[$objectHash] = [];
+        }
+
+        if (isset($this->hashMap[$objectClass][$objectHash])) {
+            return $this->hashMap[$objectClass][$objectHash];
         }
 
         $reflectedObject = new ReflectionObject($object);
@@ -186,7 +191,7 @@ class DeepCopy
 
         if (false === $isCloneable) {
             if ($this->skipUncloneable) {
-                $this->hashMap[$objectHash] = $object;
+                $this->hashMap[$objectClass][$objectHash] = $object;
 
                 return $object;
             }
@@ -200,7 +205,7 @@ class DeepCopy
         }
 
         $newObject = clone $object;
-        $this->hashMap[$objectHash] = $newObject;
+        $this->hashMap[$objectClass][$objectHash] = $newObject;
 
         if ($this->useCloneMethod && $reflectedObject->hasMethod('__clone')) {
             return $newObject;


### PR DESCRIPTION
Found this weird bug with DeepCopy where spl_object_hash returns similar hashes for different objects causing issues when deep copying.

Forking the library and adding a patch until we get that patch in.